### PR TITLE
lombok包不必要传递依赖，lombok只在maven编译期生成class字节码，并且不会包含和引用lombok自身的类信息，引用方可以无感知。

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -33,6 +33,7 @@
             <groupId>org.projectlombok</groupId>
             <artifactId>lombok</artifactId>
             <version>1.16.6</version>
+            <scope>provided</scope>
         </dependency>
 
         <!-- dubbo -->


### PR DESCRIPTION
class信息如下。

``` java
package io.tbud.boot.dubbo.filter;

import com.alibaba.dubbo.common.json.JSON;
import java.io.Serializable;
import java.util.Arrays;

public class InterfaceLog implements Serializable {
    private String invokeTime = String.valueOf(System.currentTimeMillis());
    private String methodName;
    private String senderName;
    private String senderHost;
    private String receiverName;
    private String receiverHost;
    private String srvGroup;
    private String version;
    private String[] paramTypes;
    private Object[] paramValues;
    private Object resultValue;
    private long costTime = 0L;
    private String exceptionMsg;

    public String toString() {
        String slfStr;
        try {
            slfStr = JSON.json(this);
        } catch (Exception var3) {
            slfStr = this.toSimpleString();
        }

        return slfStr;
    }

    public String toSimpleString() {
        return String.format("{\"invokeTime\": \"%s\" , \"methodName\": \"%s\", \"senderName\": \"%s\", \"senderHost\": \"%s\", \"receiverName\": \"%s\", \"receiverHost\": \"%s\", \"srvGroup\": \"%s\", \"version\": \"%s\", \"paramTypes\": [], \"paramValues\": [], \"resultValue\": {}, \"costTime\": %s, \"exceptionMsg\": \"%s\"}", new Object[]{this.invokeTime, this.methodName, this.senderName, this.senderHost, this.receiverName, this.receiverHost, this.srvGroup, this.version, Long.valueOf(this.costTime), this.exceptionMsg});
    }

    public InterfaceLog() {
    }

    public String getInvokeTime() {
        return this.invokeTime;
    }

    public String getMethodName() {
        return this.methodName;
    }

    public String getSenderName() {
        return this.senderName;
    }

    public String getSenderHost() {
        return this.senderHost;
    }

    public String getReceiverName() {
        return this.receiverName;
    }
...
```
